### PR TITLE
Implement the Twig_ExistsLoaderInterface on the loader

### DIFF
--- a/src/PuliTemplateLoader.php
+++ b/src/PuliTemplateLoader.php
@@ -16,13 +16,14 @@ use Puli\Repository\Api\Resource\BodyResource;
 use Puli\Repository\Api\ResourceNotFoundException;
 use Puli\Repository\Api\ResourceRepository;
 use Twig_Error_Loader;
+use Twig_ExistsLoaderInterface;
 use Twig_LoaderInterface;
 
 /**
  * @since  1.0
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class PuliTemplateLoader implements Twig_LoaderInterface
+class PuliTemplateLoader implements Twig_LoaderInterface, Twig_ExistsLoaderInterface
 {
     private $repo;
 
@@ -124,5 +125,17 @@ class PuliTemplateLoader implements Twig_LoaderInterface
         } catch (InvalidArgumentException $e) {
             throw new Twig_Error_Loader($e->getMessage(), -1, null, $e);
         }
+    }
+
+    /**
+     * Check if we have the source code of a template, given its name.
+     *
+     * @param string $name The name of the template to check if we can load
+     *
+     * @return bool If the template source code is handled by this loader or not
+     */
+    public function exists($name)
+    {
+        return $this->repo->contains($name);
     }
 }

--- a/tests/PuliTemplateLoaderTest.php
+++ b/tests/PuliTemplateLoaderTest.php
@@ -64,4 +64,14 @@ class PuliTemplateLoaderTest extends PHPUnit_Framework_TestCase
 
         $this->loader->isFresh('/webmozart/puli/file', 123);
     }
+
+    public function testExistsReturnsFalseIfNoFileResource()
+    {
+        $this->repo->expects($this->once())
+            ->method('contains')
+            ->with('/webmozart/puli/file')
+            ->willReturn(false);
+
+        $this->assertFalse($this->loader->exists('/webmozart/puli/file'));
+    }
 }


### PR DESCRIPTION
Closes https://github.com/puli/issues/issues/74

Note that this implementation is not fully optimized compared to changes done in Twig core loaders, because it still relies on catching exceptions (which is where Twig won on performance when avoiding it). But I don't know the Puli API enough to know whether it can be optimized more.
so the main benefit of the PR currently is forward-compatibility with Twig 2.x.