### PR TITLE
Make the extension compatible with Twig 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.9",
         "puli/repository": "1.0.*",
-        "twig/twig": "^1.12",
+        "twig/twig": "^1.20|^2.0",
         "webmozart/path-util": "^2.0"
     },
     "require-dev": {

--- a/src/NodeVisitor/AbstractPathResolver.php
+++ b/src/NodeVisitor/AbstractPathResolver.php
@@ -12,10 +12,10 @@
 namespace Puli\TwigExtension\NodeVisitor;
 
 use Puli\Repository\Api\ResourceRepository;
+use Twig_BaseNodeVisitor;
 use Twig_Environment;
+use Twig_Node;
 use Twig_Node_Module;
-use Twig_NodeInterface;
-use Twig_NodeVisitorInterface;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -23,7 +23,7 @@ use Webmozart\PathUtil\Path;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class AbstractPathResolver implements Twig_NodeVisitorInterface
+abstract class AbstractPathResolver extends Twig_BaseNodeVisitor
 {
     /**
      * @var ResourceRepository
@@ -41,14 +41,9 @@ abstract class AbstractPathResolver implements Twig_NodeVisitorInterface
     }
 
     /**
-     * Called before child nodes are visited.
-     *
-     * @param Twig_NodeInterface $node The node to visit
-     * @param Twig_Environment   $env  The Twig environment instance
-     *
-     * @return Twig_NodeInterface The modified node
+     * {@inheritdoc}
      */
-    public function enterNode(Twig_NodeInterface $node, Twig_Environment $env)
+    protected function doEnterNode(Twig_Node $node, Twig_Environment $env)
     {
         // Remember the directory of the current file
         if ($node instanceof Twig_Node_Module && $node->hasAttribute('puli-dir')) {
@@ -63,14 +58,9 @@ abstract class AbstractPathResolver implements Twig_NodeVisitorInterface
     }
 
     /**
-     * Called after child nodes are visited.
-     *
-     * @param Twig_NodeInterface $node The node to visit
-     * @param Twig_Environment   $env  The Twig environment instance
-     *
-     * @return Twig_NodeInterface|false The modified node or false if the node must be removed
+     * {@inheritdoc}
      */
-    public function leaveNode(Twig_NodeInterface $node, Twig_Environment $env)
+    protected function doLeaveNode(Twig_Node $node, Twig_Environment $env)
     {
         // Only process if the current directory was set
         if (null !== $this->currentDir) {
@@ -114,9 +104,9 @@ abstract class AbstractPathResolver implements Twig_NodeVisitorInterface
     }
 
     /**
-     * @param Twig_NodeInterface $node
+     * @param Twig_Node $node
      *
-     * @return Twig_NodeInterface
+     * @return Twig_Node|null
      */
-    abstract protected function processNode(Twig_NodeInterface $node);
+    abstract protected function processNode(Twig_Node $node);
 }

--- a/src/NodeVisitor/PuliDirTagger.php
+++ b/src/NodeVisitor/PuliDirTagger.php
@@ -12,12 +12,11 @@
 namespace Puli\TwigExtension\NodeVisitor;
 
 use Puli\TwigExtension\Node\LoadedByPuliNode;
+use Twig_BaseNodeVisitor;
 use Twig_Environment;
 use Twig_Node;
 use Twig_Node_Body;
 use Twig_Node_Module;
-use Twig_NodeInterface;
-use Twig_NodeVisitorInterface;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -31,7 +30,7 @@ use Webmozart\PathUtil\Path;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class PuliDirTagger implements Twig_NodeVisitorInterface
+class PuliDirTagger extends Twig_BaseNodeVisitor
 {
     /**
      * @var Twig_Node_Module|null
@@ -41,12 +40,12 @@ class PuliDirTagger implements Twig_NodeVisitorInterface
     /**
      * Called before child nodes are visited.
      *
-     * @param Twig_NodeInterface $node The node to visit
-     * @param Twig_Environment   $env  The Twig environment instance
+     * @param Twig_Node        $node The node to visit
+     * @param Twig_Environment $env  The Twig environment instance
      *
-     * @return Twig_NodeInterface The modified node
+     * @return Twig_Node The modified node
      */
-    public function enterNode(Twig_NodeInterface $node, Twig_Environment $env)
+    protected function doEnterNode(Twig_Node $node, Twig_Environment $env)
     {
         if ($node instanceof Twig_Node_Module) {
             $this->moduleNode = $node;
@@ -58,12 +57,12 @@ class PuliDirTagger implements Twig_NodeVisitorInterface
     /**
      * Called after child nodes are visited.
      *
-     * @param Twig_NodeInterface $node The node to visit
-     * @param Twig_Environment   $env  The Twig environment instance
+     * @param Twig_Node        $node The node to visit
+     * @param Twig_Environment $env  The Twig environment instance
      *
-     * @return Twig_NodeInterface|false The modified node or false if the node must be removed
+     * @return Twig_Node|false The modified node or false if the node must be removed
      */
-    public function leaveNode(Twig_NodeInterface $node, Twig_Environment $env)
+    protected function doLeaveNode(Twig_Node $node, Twig_Environment $env)
     {
         // Tag the node if it contains a LoadedByPuliNode
         // This cannot be done in enterNode(), because only leaveNode() may

--- a/src/NodeVisitor/TemplatePathResolver.php
+++ b/src/NodeVisitor/TemplatePathResolver.php
@@ -21,7 +21,6 @@ use Twig_Node_Expression_Function;
 use Twig_Node_Import;
 use Twig_Node_Include;
 use Twig_Node_Module;
-use Twig_NodeInterface;
 
 /**
  * @since  1.0
@@ -63,7 +62,7 @@ class TemplatePathResolver extends AbstractPathResolver
     /**
      * {@inheritdoc}
      */
-    protected function processNode(Twig_NodeInterface $node)
+    protected function processNode(Twig_Node $node)
     {
         if ($node instanceof Twig_Node_Module) {
             return $this->processModuleNode($node);

--- a/tests/CacheWarmer/TwigTemplateCacheWarmerTest.php
+++ b/tests/CacheWarmer/TwigTemplateCacheWarmerTest.php
@@ -28,7 +28,9 @@ class TwigTemplateCacheWarmerTest extends PHPUnit_Framework_TestCase
         $repo = new InMemoryRepository();
         $repo->add('/webmozart/puli', new DirectoryResource(__DIR__.'/Fixtures'));
 
-        $twig = $this->getMock('Twig_Environment', array('loadTemplate'));
+        $twig = $this->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $warmer = new TwigTemplateCacheWarmer($repo, $twig);
 

--- a/tests/RandomizedTwigEnvironment.php
+++ b/tests/RandomizedTwigEnvironment.php
@@ -40,9 +40,13 @@ class RandomizedTwigEnvironment extends Twig_Environment
         // Make sure the template class prefix is different for every new
         // instance of this class to isolate the tests
         do {
-            $this->templateClassPrefix = '__TwigTemplate_'.rand(10000, 99999).'_';
-        } while (isset(self::$previousPrefixes[$this->templateClassPrefix]));
+            $templateClassPrefix = '__TwigTemplate_'.rand(10000, 99999).'_';
+        } while (isset(self::$previousPrefixes[$templateClassPrefix]));
 
-        self::$previousPrefixes[$this->templateClassPrefix] = true;
+        self::$previousPrefixes[$templateClassPrefix] = true;
+
+        $p = new \ReflectionProperty('Twig_Environment', 'templateClassPrefix');
+        $p->setAccessible(true);
+        $p->setValue($this, $templateClassPrefix);
     }
 }


### PR DESCRIPTION
This includes a BC break in AbstractPathResolver to change the typehint to stop using the deprecated Twig_NodeInterface.
Given that Puli is not yet stable, I think it might be fine to make this BC break rather than keeping a BC layer by adding a new protected method with a different name to be overwritten by updated implementations