### PR TITLE
Fix support for Twig 1.25

### DIFF
--- a/src/NodeVisitor/TemplatePathResolver.php
+++ b/src/NodeVisitor/TemplatePathResolver.php
@@ -86,7 +86,7 @@ class TemplatePathResolver extends AbstractPathResolver
     private function processModuleNode(Twig_Node_Module $node)
     {
         // Resolve relative parent template paths to absolute paths
-        $parentNode = $node->getNode('parent');
+        $parentNode = $node->hasNode('parent') ? $node->getNode('parent') : null;
         $traitsNode = $node->getNode('traits');
 
         // If the template extends another template, resolve the path
@@ -109,7 +109,7 @@ class TemplatePathResolver extends AbstractPathResolver
 
     private function processEmbeddedTemplateNode(Twig_Node_Module $embeddedNode)
     {
-        $embedParent = $embeddedNode->getNode('parent');
+        $embedParent = $embeddedNode->hasParent('parent') ? $embeddedNode->getNode('parent') : null;
 
         // If the template extends another template, resolve the path
         if ($embedParent instanceof Twig_Node_Expression_Constant) {

--- a/src/NodeVisitor/TemplatePathResolver.php
+++ b/src/NodeVisitor/TemplatePathResolver.php
@@ -109,7 +109,7 @@ class TemplatePathResolver extends AbstractPathResolver
 
     private function processEmbeddedTemplateNode(Twig_Node_Module $embeddedNode)
     {
-        $embedParent = $embeddedNode->hasParent('parent') ? $embeddedNode->getNode('parent') : null;
+        $embedParent = $embeddedNode->hasNode('parent') ? $embeddedNode->getNode('parent') : null;
 
         // If the template extends another template, resolve the path
         if ($embedParent instanceof Twig_Node_Expression_Constant) {


### PR DESCRIPTION
Fix the unit test https://github.com/puli/twig-extension/pull/24 .

There is no `hasParent('parent')`, but `hasNode('parent')` .
